### PR TITLE
Add PrebuiltApps

### DIFF
--- a/Nexus6P/build/make/0001-PRODUCT_PACKAGES-add-ipfs.patch
+++ b/Nexus6P/build/make/0001-PRODUCT_PACKAGES-add-ipfs.patch
@@ -1,7 +1,7 @@
 From 50ce616955f4886773339478cf7770944b705742 Mon Sep 17 00:00:00 2001
 From: "winton.liu" <admin@brahmaos.io>
 Date: Wed, 20 Jun 2018 09:35:52 +0800
-Subject: [PATCH 1/2] PRODUCT_PACKAGES: add ipfs
+Subject: [PATCH 1/3] PRODUCT_PACKAGES: add ipfs
 
 build ipfs for default
 

--- a/Nexus6P/build/make/0002-PRODUCT_PACKAGES-add-BrahmaWallet.patch
+++ b/Nexus6P/build/make/0002-PRODUCT_PACKAGES-add-BrahmaWallet.patch
@@ -1,7 +1,7 @@
 From e05f34cce63f0afc033bec0def35d98b7c3e345a Mon Sep 17 00:00:00 2001
 From: "winton.liu" <admin@brahmaos.io>
 Date: Thu, 21 Jun 2018 14:56:24 +0800
-Subject: [PATCH 2/2] PRODUCT_PACKAGES: add BrahmaWallet
+Subject: [PATCH 2/3] PRODUCT_PACKAGES: add BrahmaWallet
 
 build BrahmaWallet for default
 

--- a/Nexus6P/build/make/0003-core.mk-update-PRODUCT_PACKAGES.patch
+++ b/Nexus6P/build/make/0003-core.mk-update-PRODUCT_PACKAGES.patch
@@ -1,0 +1,46 @@
+From 1184a2aa948d20709d4b3d1cc58ea7074f0d7a1a Mon Sep 17 00:00:00 2001
+From: "winton.liu" <admin@brahmaos.io>
+Date: Fri, 29 Jun 2018 14:14:42 +0800
+Subject: [PATCH 3/3] core.mk: update PRODUCT_PACKAGES
+
+1.Delete Browser2 and QuickSearchBox
+2.Add preloadapp which contains BrahmaWallet
+
+Change-Id: I75c7ff5ab0bc6789fa7b57a1911a84306e4c8ffc
+Signed-off-by: winton.liu <admin@brahmaos.io>
+---
+ target/product/core.mk | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/target/product/core.mk b/target/product/core.mk
+index f8dcf97..48667e7 100644
+--- a/target/product/core.mk
++++ b/target/product/core.mk
+@@ -24,7 +24,6 @@ PRODUCT_PACKAGES += \
+     BasicDreams \
+     BlockedNumberProvider \
+     BookmarkProvider \
+-    Browser2 \
+     BuiltInPrintService \
+     Calendar \
+     CalendarProvider \
+@@ -51,7 +50,6 @@ PRODUCT_PACKAGES += \
+     PrintSpooler \
+     PrintRecommendationService \
+     ProxyHandler \
+-    QuickSearchBox \
+     Settings \
+     SharedStorageBackup \
+     StorageManager \
+@@ -61,7 +59,7 @@ PRODUCT_PACKAGES += \
+     vr \
+     MmsService \
+     ipfs \
+-    BrahmaWallet
++    preloadapp
+ 
+ # The set of packages whose code can be loaded by the system server.
+ PRODUCT_SYSTEM_SERVER_APPS += \
+-- 
+2.7.4
+

--- a/Nexus6P/frameworks/base/0001-NetworkMonitor-fix-Wifi-Connected-no-Internet.patch
+++ b/Nexus6P/frameworks/base/0001-NetworkMonitor-fix-Wifi-Connected-no-Internet.patch
@@ -1,7 +1,7 @@
 From 62d7db8c947c70f47c7839680961b8977632e2a0 Mon Sep 17 00:00:00 2001
 From: "winton.liu" <admin@brahmaos.io>
 Date: Fri, 1 Jun 2018 16:51:34 +0800
-Subject: [PATCH 1/2] NetworkMonitor: fix Wifi "Connected, no Internet"
+Subject: [PATCH 1/3] NetworkMonitor: fix Wifi "Connected, no Internet"
 
 For some reason, China networks can't access google network.
 Replace google http service URL with brahamos service URL,

--- a/Nexus6P/frameworks/base/0002-NTP-fix-the-time-is-not-correct-in-China.patch
+++ b/Nexus6P/frameworks/base/0002-NTP-fix-the-time-is-not-correct-in-China.patch
@@ -1,7 +1,7 @@
 From 5775ce343aa8ecba745c6af284578b0160d57d2a Mon Sep 17 00:00:00 2001
 From: "winton.liu" <admin@brahmaos.io>
 Date: Tue, 5 Jun 2018 17:44:28 +0800
-Subject: [PATCH 2/2] NTP: fix the time is not correct in China
+Subject: [PATCH 2/3] NTP: fix the time is not correct in China
 
 Ntp server time.android.com is not accessible in China.
 So modify the ntpServer to "time.asia.apple.com".

--- a/Nexus6P/frameworks/base/0003-PackageManagerService-fix-scan-data-app-error.patch
+++ b/Nexus6P/frameworks/base/0003-PackageManagerService-fix-scan-data-app-error.patch
@@ -1,0 +1,30 @@
+From 2bc40a557fc48d6a2904cf83aec3c8afd962769d Mon Sep 17 00:00:00 2001
+From: "winton.liu" <admin@brahmaos.io>
+Date: Fri, 29 Jun 2018 17:44:22 +0800
+Subject: [PATCH 3/3] PackageManagerService: fix scan /data/app error
+
+To ensure /data/app could be installed after flashing image,
+don't use SCAN_REQUIRE_KNOWN flag.
+
+Change-Id: If17528e50629162399ec6d3670c12320b9800237
+Signed-off-by: winton.liu <admin@brahmaos.io>
+---
+ services/core/java/com/android/server/pm/PackageManagerService.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/services/core/java/com/android/server/pm/PackageManagerService.java b/services/core/java/com/android/server/pm/PackageManagerService.java
+index 06600bf..eb7bc73 100644
+--- a/services/core/java/com/android/server/pm/PackageManagerService.java
++++ b/services/core/java/com/android/server/pm/PackageManagerService.java
+@@ -2759,7 +2759,7 @@ public class PackageManagerService extends IPackageManager.Stub
+             if (!mOnlyCore) {
+                 EventLog.writeEvent(EventLogTags.BOOT_PROGRESS_PMS_DATA_SCAN_START,
+                         SystemClock.uptimeMillis());
+-                scanDirTracedLI(mAppInstallDir, 0, scanFlags | SCAN_REQUIRE_KNOWN, 0);
++                scanDirTracedLI(mAppInstallDir, 0, scanFlags , 0);
+ 
+                 scanDirTracedLI(mDrmAppPrivateInstallDir, mDefParseFlags
+                         | PackageParser.PARSE_FORWARD_LOCK,
+-- 
+2.7.4
+

--- a/Nexus6P/system/sepolicy/0001-selinux-add-sepolicy-for-ipfs.patch
+++ b/Nexus6P/system/sepolicy/0001-selinux-add-sepolicy-for-ipfs.patch
@@ -1,7 +1,7 @@
 From fc83588b974293e5bc6b2692f1ec070b2391eadb Mon Sep 17 00:00:00 2001
 From: "winton.liu" <admin@brahmaos.io>
 Date: Wed, 20 Jun 2018 09:46:51 +0800
-Subject: [PATCH] selinux: add sepolicy for ipfs
+Subject: [PATCH 1/2] selinux: add sepolicy for ipfs
 
 add sepolicy for ipfs
 

--- a/Nexus6P/system/sepolicy/0002-Selinux-add-preloadapp.te-sepolicy.patch
+++ b/Nexus6P/system/sepolicy/0002-Selinux-add-preloadapp.te-sepolicy.patch
@@ -1,0 +1,50 @@
+From 0c32d32f535b556b184082565ad5b0d36426868a Mon Sep 17 00:00:00 2001
+From: "winton.liu" <admin@brahmaos.io>
+Date: Fri, 29 Jun 2018 14:30:53 +0800
+Subject: [PATCH 2/2] Selinux: add preloadapp.te sepolicy
+
+add sepolicy for preloadapp
+
+Change-Id: I9c4ff7e14e06ea141959d54973d4f193f3ccc82a
+Signed-off-by: winton.liu <admin@brahmaos.io>
+---
+ private/file_contexts |  1 +
+ private/preloadapp.te | 14 ++++++++++++++
+ 2 files changed, 15 insertions(+)
+ create mode 100644 private/preloadapp.te
+
+diff --git a/private/file_contexts b/private/file_contexts
+index bb565b1..0ca649d 100644
+--- a/private/file_contexts
++++ b/private/file_contexts
+@@ -277,6 +277,7 @@
+ 
+ # BrahmaOS files
+ /system/bin/ipfs                u:object_r:ipfs_exec:s0
++/system/bin/preloadapp          u:object_r:preloadapp_exec:s0
+ 
+ #############################
+ # Vendor files
+diff --git a/private/preloadapp.te b/private/preloadapp.te
+new file mode 100644
+index 0000000..321b272
+--- /dev/null
++++ b/private/preloadapp.te
+@@ -0,0 +1,14 @@
++# preloadapp service
++type preloadapp, domain, mlstrustedsubject;
++type preloadapp_exec, exec_type, file_type;
++
++#typeattribute preloadapp coredomain;
++init_daemon_domain(preloadapp)
++
++set_prop(preloadapp, system_prop)
++allow preloadapp shell_exec:file rx_file_perms;
++allow preloadapp system_file:dir r_dir_perms;
++allow preloadapp apk_data_file:dir create_dir_perms;
++allow preloadapp apk_data_file:file create_file_perms; 
++allow preloadapp toolbox_exec:file rx_file_perms;
++allow preloadapp self:capability dac_override;
+-- 
+2.7.4
+


### PR DESCRIPTION
Thi is a package maintains prebuilt apps.
It contains 4 parts.
preloadapp: prebuild app which user could uninstall (reset will recovery).
        Installed in /system/preloadapp
systemapp:  prebuild app which couldn't uninstall
        Installed in /system/app
dataapp:    prebuild app which user could uninstall (reset will lose)
        Installed in /data/app
lib:        prebuild library
        Installed in /system/lib

https://github.com/BrahmaOS/brahmaos-packages-apps-PrebuiltApps

Signed-off-by: winton.liu <admin@brahmaos.io>